### PR TITLE
feat: add free user and override retrieve password message

### DIFF
--- a/harness-inspections.php
+++ b/harness-inspections.php
@@ -29,6 +29,30 @@ add_action( 'plugins_loaded', function() {
     add_action('init', 'init');
     add_action( 'acf/init', 'initACF');
     add_action( 'graphql_register_types', 'initGraphQLRegister');
+    add_role('free_user', 'Free User', array('read' => true, 'level_0' => true));
+
+    add_filter( 'retrieve_password_message', function( $message, $key, $user_login, $user_data ) {
+      $user_email = $user_data->user_email;
+      $site_name = 'Harness Software Inspection App';
+      $message   = __( 'Someone has requested a password reset for the following account:' ) . "\r\n\r\n";
+      /* translators: %s: Site name. */
+      $message .= sprintf( __( 'Site Name: %s', 'Harness Software Inspection App' ), $site_name ) . "\r\n\r\n";
+      /* translators: %s: User login. */
+      $message .= sprintf( __( 'Username: %s', 'Harness Software Inspection App' ), $user_login ) . "\r\n\r\n";
+      $message .= sprintf( __( 'Email Address: %s', 'Harness Software Inspection App' ), $user_email ) . "\r\n\r\n";
+      $message .= __( 'If this was a mistake, ignore this email and nothing will happen.' ) . "\r\n\r\n";
+      $message .= __( 'To reset your password, visit the following address:' ) . "\r\n\r\n";
+      $message .= home_url() . '/app/password-reset/' . $key ."?email=" . rawurlencode( $user_email ) . "&username=" . rawurlencode($user_login) . "\r\n\r\n";
+      $requester_ip = $_SERVER['REMOTE_ADDR'];
+      if ( $requester_ip ) {
+          $message .= sprintf(
+          /* translators: %s: IP address of password reset requester. */
+              __( 'This password reset request originated from the IP address %s.' ),
+              $requester_ip
+          ) . "\r\n";
+      }
+      return $message;
+    }, 10, 4 );
   }
 }, 0);
 

--- a/harness-inspections.php
+++ b/harness-inspections.php
@@ -42,7 +42,7 @@ add_action( 'plugins_loaded', function() {
       $message .= sprintf( __( 'Email Address: %s', 'Harness Software Inspection App' ), $user_email ) . "\r\n\r\n";
       $message .= __( 'If this was a mistake, ignore this email and nothing will happen.' ) . "\r\n\r\n";
       $message .= __( 'To reset your password, visit the following address:' ) . "\r\n\r\n";
-      $message .= home_url() . '/app/password-reset/' . $key ."?email=" . rawurlencode( $user_email ) . "&username=" . rawurlencode($user_login) . "\r\n\r\n";
+      $message .= getenv('CLIENT_URL') . '/app/password-reset/' . $key ."?email=" . rawurlencode( $user_email ) . "&username=" . rawurlencode($user_login) . "\r\n\r\n";
       $requester_ip = $_SERVER['REMOTE_ADDR'];
       if ( $requester_ip ) {
           $message .= sprintf(


### PR DESCRIPTION
Functionality added to the plugin to:

1) add free user
![free-user](https://user-images.githubusercontent.com/79232004/112868836-81a6a200-908a-11eb-8d11-b978bcaab409.png)

2) override retrieve password message
![reset-email](https://user-images.githubusercontent.com/79232004/112868893-9125eb00-908a-11eb-9acc-332d4e55d528.png)


After testing that it worked locally in our backend setup I thought it best to add the overriding password functionality in the plugin itself so that this functionality will remain in place even if we had to change themes.